### PR TITLE
Added support for TORQUE (open source PBS):

### DIFF
--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -61,6 +61,9 @@ my $bamheader;
 my $PBSPro = 0;
 my $PBSPro_select;
 my $PBSPro_A;
+my $torque = 0;
+my $torque_select;
+my $torque_A;
 my $preExec;
 my $useGinsi;
 
@@ -79,6 +82,9 @@ GetOptions (
 	'PBSPro:s' => \$PBSPro,
 	'PBSPro_select:s' => \$PBSPro_select,
 	'PBSPro_A:s' => \$PBSPro_A,
+	'torque:s' => \$torque,
+	'torque_select:s' => \$torque_select,
+	'torque_A:s' => \$torque_A,
 	'useGinsi:s' => \$useGinsi,
 	'preExec:s' => \$preExec,
 );
@@ -397,6 +403,19 @@ sub invoke_self_array
 
 jobID=\$(expr \$PBS_ARRAY_INDEX - 1)
 );		
+		}
+		elsif($torque)
+		{
+		print QSUB qq(#!/bin/bash
+#PBS -l $torque_select
+#PBS -l walltime=23:00:00
+#PBS -A '$torque_A'
+#PBS -N CALLMAFFT
+#PBS -t ${minJobID}-${maxJobID}
+#PBS -r y
+
+jobID=\$(expr \$PBS_ARRAYID - 1)
+);
 		}
 		else
 		{

--- a/suggestCommands.pl
+++ b/suggestCommands.pl
@@ -144,6 +144,8 @@ perl scripts/BAM2MAFFT.pl --BAM  ${outputDirectory}/${prefix}_forMAFFT.bam --ref
 # If you have no cluster available, you can specify --qsub 0 to directly execute all required MSA commands, but be prepared for this to take a rather long time.
 # If you are using PBSPro instead of SGE, you can add the following arguments (modified for your local environment):
 #        --PBSPro 1 --PBSPro_select 'select=1:ncpus=16:mem=48GB' --PBSPro_A IMMGEN --preExec 'module load Perl; module load SamTools; module load Mafft/7.407' --chunkSize 500
+# If you are using the open source scheduler TORQUE, you can add the following arguments (modified for your local environment):
+#        --torque 1 --torque_select 'select=1:ncpus=16:mem=48GB' --torque_A IMMGEN --preExec 'module load Perl; module load SamTools; module load Mafft/7.407' --chunkSize 500
 # The --chunkSize parameter determines how many alignment jobs are assigned to each submitted job on your cluster, i.e. as you increase --chunkSize, the total number
 # of submitted jobs is reduced.
 perl scripts/CALLMAFFT.pl --action kickOff --mafftDirectory  ${outputDirectory}/intermediate_files/${prefix}_forMAFFT --mafft_executable $mafft_executable --fas2bam_path scripts/fas2bam.pl --samtools_path $samtools_path --bamheader windowbam.header.txt --qsub $qsub $ginsiMAFFT


### PR DESCRIPTION
In suggestCommands.pl, add description of torque options for users
who are running TORQUE. In CALLMAFFT.pl, print correct qsub options
for TORQUE, i.e., -t rather than -J for job ids, and $PBS_ARRAYID
rather than $PBS_ARRAY_INDEX for retrieving job index from within
submitted scripts.