### PR TITLE
Splitting is necessary for assemblies with long stretches of N becaus…

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Some important notes:
 
 
 ```
+## If you have long stretches of undetermined nucleotides (Ns) in your input fasta files or if you want
+## to add a specific prefix to you input fastas you can use this helper script
+python split_identify_fasta.py --Ns 6 assembly1.fa prefix_for_assembly1 assembly1_split.fa
+
+## Concatenate the input fasta files
+cat assembly1_split.fa assembly2_split.fa assembly3_split.fa > allContigs.fa
+
 ## Align the contigs FASTA against the reference, outputting a single BAM
 minimap2 -a -x asm20 GRCh38_full_plus_hs38d1_analysis_set_minus_alts allContigs.fa  | samtools view -Sb - > allContigs_unsorted.bam
 

--- a/scripts/split_identify_fasta.py
+++ b/scripts/split_identify_fasta.py
@@ -1,0 +1,36 @@
+from argparse import ArgumentParser
+from Bio import SeqIO
+import re
+
+parser = ArgumentParser()
+parser.add_argument("inputfile", help = "Input File in fasta format")
+parser.add_argument("prefix", help = "This will be prefixed to the fasta ids")
+parser.add_argument("outputfile", help="Output with split fasta records")
+parser.add_argument("--Ns", type = int, default = 5000, help = "Number of Ns to split by [5000]")
+
+args = parser.parse_args()
+
+with open(args.outputfile, "w+") as outf:
+    for read in SeqIO.parse(args.inputfile, "fasta"):
+        print(read.id)
+
+        s = str(read.seq.upper().lstrip("N").rstrip("N"))
+        matches = re.finditer("N{" + str(args.Ns) + ",}", s)
+        start = 0
+        partnr = 1
+        for m in matches:
+            nstart, nstop = m.span()
+            #print(s[m.span()[1]])
+            part = s[start:nstart]
+
+            outf.write(">" + args.prefix + "_" + read.id + "_" + str(partnr) + "\n")
+            outf.write(part + "\n")
+
+            partnr += 1
+            start = nstop
+        part = s[start:]
+        outf.write(">" + args.prefix + "_" + read.id + "_" + str(partnr) + "\n")
+        outf.write(part + "\n")
+        
+        print("found " + str(partnr) + " parts")
+

--- a/scripts/split_identify_fasta.py
+++ b/scripts/split_identify_fasta.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from argparse import ArgumentParser
 import sys
 import re

--- a/scripts/split_identify_fasta.py
+++ b/scripts/split_identify_fasta.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentParser
-from Bio import SeqIO
+import sys
 import re
 
 parser = ArgumentParser()
@@ -11,26 +11,33 @@ parser.add_argument("--Ns", type = int, default = 5000, help = "Number of Ns to 
 args = parser.parse_args()
 
 with open(args.outputfile, "w+") as outf:
-    for read in SeqIO.parse(args.inputfile, "fasta"):
-        print(read.id)
+    with open(args.inputfile) as f:
+        for linenr, line in enumerate(f):
+            if linenr % 2 == 0:
+                rid = line.rstrip().lstrip(">")
+            else:
+                if line[0] not in {'A', 'G', 'C', 'T', 'N'}:
+                    print("Error found in input file. Make sure the input is in correct fasta format.")
+                    sys.exit()
+                print(rid + "... ", end = "")
 
-        s = str(read.seq.upper().lstrip("N").rstrip("N"))
-        matches = re.finditer("N{" + str(args.Ns) + ",}", s)
-        start = 0
-        partnr = 1
-        for m in matches:
-            nstart, nstop = m.span()
-            #print(s[m.span()[1]])
-            part = s[start:nstart]
+                s = line.rstrip().upper().lstrip("N").rstrip("N")
+                matches = re.finditer("N{" + str(args.Ns) + ",}", s)
+                start = 0
+                partnr = 1
+                for m in matches:
+                    nstart, nstop = m.span()
+                    #print(s[m.span()[1]])
+                    part = s[start:nstart]
 
-            outf.write(">" + args.prefix + "_" + read.id + "_" + str(partnr) + "\n")
-            outf.write(part + "\n")
+                    outf.write(">" + args.prefix + "_" + rid + "_" + str(partnr) + "\n")
+                    outf.write(part + "\n")
 
-            partnr += 1
-            start = nstop
-        part = s[start:]
-        outf.write(">" + args.prefix + "_" + read.id + "_" + str(partnr) + "\n")
-        outf.write(part + "\n")
-        
-        print("found " + str(partnr) + " parts")
+                    partnr += 1
+                    start = nstop
+                part = s[start:]
+                outf.write(">" + args.prefix + "_" + rid + "_" + str(partnr) + "\n")
+                outf.write(part + "\n")
+                
+                print("found " + str(partnr) + " parts")
 

--- a/suggestCommands.pl
+++ b/suggestCommands.pl
@@ -123,7 +123,7 @@ my $samtools_view_header = ($limitToPGF) ? 'pgf.GrCh38.headerfile.txt' : 'GRCh38
 print qq(
 
 # If your contigs are interspersed with long stretches of unknown nucleotides (NNN...NNN) you should split them:
-# needs: Python 3 and biopython
+# needs: Python 3
 python scripts/split_identify_fasta.py $inputContigs > ${outputDirectory}/split_${inputContigs}
 
 # Map your input contigs with minimap2:

--- a/suggestCommands.pl
+++ b/suggestCommands.pl
@@ -122,11 +122,15 @@ my $samtools_view_header = ($limitToPGF) ? 'pgf.GrCh38.headerfile.txt' : 'GRCh38
 
 print qq(
 
+# If your contigs are interspersed with long stretches of unknown nucleotides (NNN...NNN) you should split them:
+# needs: Python 3 and biopython
+python scripts/split_identify_fasta.py $inputContigs > ${outputDirectory}/split_${inputContigs}
+
 # Map your input contigs with minimap2:
-minimap2 -t 4 -a -x asm20 $referenceGenome  $inputContigs | $samtools_path view -Sb - > ${outputDirectory}/${prefix}_allContigs_unsorted.bam
+minimap2 -t 4 -a -x asm20 $referenceGenome ${outputDirectory}/split_${inputContigs} | $samtools_path view -Sb - > ${outputDirectory}/${prefix}_allContigs_unsorted.bam
 
 # You could also use bwa:
-# bwa mem -t 4 $referenceGenome  $inputContigs | $samtools_path view -Sb - > ${outputDirectory}/${prefix}_allContigs_unsorted.bam
+# bwa mem -t 4 $referenceGenome  ${outputDirectory}/split_${inputContigs} | $samtools_path view -Sb - > ${outputDirectory}/${prefix}_allContigs_unsorted.bam
 
 # Check that the following command returns 0 - otherwise remove entries of unmapped entries from BAM:
 $samtools_path view -c -f 0x4 ${outputDirectory}/${prefix}_allContigs_unsorted.bam


### PR DESCRIPTION
…e MAFFT gets problems otherwise.

