### PR TITLE
added parameter specifying max. number processes run

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ perl CRAM2VCF.pl --CRAM combined.cram
  
 
 ## Next, execute launch_CRAM2VCF_C++.pl
-perl launch_CRAM2VCF_C++.pl --prefix graph
+perl launch_CRAM2VCF_C++.pl --prefix graph --number_processes 10
 
 
 ## Finally, run CRAM2VCF_createFinalVCF.pl 

--- a/scripts/launch_CRAM2VCF_C++.pl
+++ b/scripts/launch_CRAM2VCF_C++.pl
@@ -110,6 +110,8 @@ for(my $iI = 0; $iI <= $#indices; $iI++)
 	$runningSize += (-s $inputFiles[$i]);
 }
 
+my %still_running;
+
 if($totalCommands == 0)
 {
 	print "\nAll done.\n\n";

--- a/scripts/launch_CRAM2VCF_C++.pl
+++ b/scripts/launch_CRAM2VCF_C++.pl
@@ -15,20 +15,31 @@ require POSIX;    # provides WNOHANG
 $SIG{CHLD} = \&reap_kids;
 
 ## Usage:
-## launch_CRAM2VCF_C++.pl --prefix <path to output VCF without .VCF at the end>
+## launch_CRAM2VCF_C++.pl --prefix <path to output VCF without .VCF at the end> --number_processes <integer of total number of processes to run simultaneously>
 ##
 ## Example command:
-## ./launch_CRAM2VCF_C++.pl --prefix VCF/graph_v2.vcf
+## ./launch_CRAM2VCF_C++.pl --prefix VCF/graph_v2.vcf --number_processes 3
 
 $| = 1;
 
 my $output;
+my $number_processes;
 
 GetOptions (
 	'prefix:s' => \$output,
+	'number_processes:s' => \$number_processes
 );
 
 die "Please specify --prefix" unless($output);
+## die "Please specify the total number of processes to be simultaneously run --processes" unless($processes);
+
+## if undefined, set 
+if (not defined $number_processes){
+	$number_processes = 2;
+}
+
+die "Please specify a positive integer for input parameter `--number_processes` " unless ( $number_processes=~ /^[+]?\d+$/ && $number_processes != 0  );
+
 
 my $files_done = 0;
 my @commands;
@@ -99,8 +110,6 @@ for(my $iI = 0; $iI <= $#indices; $iI++)
 	$runningSize += (-s $inputFiles[$i]);
 }
 
-my %still_running;
-
 if($totalCommands == 0)
 {
 	print "\nAll done.\n\n";
@@ -110,7 +119,7 @@ else
 	foreach my $iI (@indices)
 	{
 		my $command = $commands[$iI];
-		while(scalar(keys %still_running) >= 10)
+		while(scalar(keys %still_running) >= $number_processes)
 		{
 			sleep 10;
 		}


### PR DESCRIPTION
Related to this issue: https://github.com/NCBI-Hackathons/NovoGraph/issues/23

I added an optional parameter to use, as opposed to the default value of 10 in the line `while(scalar(keys %still_running) >= 10)`

I set the default value to 2---please feel free to use a larger value of course!

Previously, the script had the following code:

https://github.com/NCBI-Hackathons/NovoGraph/blob/master/scripts/launch_CRAM2VCF_C%2B%2B.pl#L102-L116

```
my %still_running;

if($totalCommands == 0)
{
	print "\nAll done.\n\n";
}
else
{
	foreach my $iI (@indices)
	{
		my $command = $commands[$iI];
		while(scalar(keys %still_running) >= 10)
		{
			sleep 10;
		}
		
		my $pid = fork;
		die "fork failed" unless defined $pid;
		if ($pid == 0) {
			system($command) and die "Could not execute command: $command";
			exit;
		}		
		$still_running{$pid} = 1;			
	}
	
	print "\n\nProcesses launched.\n";
}
```

I also added a check to make sure it's a positive integer. 

There's probably a better name for this parameter---please come up with something!

TDIL: I'm also fascinated that apparently the colon `:` in GetOptions specifies an optional argument: https://stackoverflow.com/questions/6555644/how-to-use-getoptions-utility-to-handle-optional-command-line-arguments-in-per

