### PR TITLE
revised README, added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Torsten Houwaart (torsten.houwaart@med.uni-duesseldorf.de)" \
+      version.ubuntu="18.04"
+
+# install required packages
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    liblist-moreutils-perl \
+    libset-intervaltree-perl \
+    python3.6
+RUN ln -s /usr/bin/python3.6 /usr/bin/python
+
+# necessary for Bio:DB::HTS 
+RUN apt-get update && apt-get install -y \
+    cpanminus \
+    wget \
+    zlib1g-dev \
+    liblzma-dev \
+    libbz2-dev \
+    bioperl
+RUN cd /opt \
+    && wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 \
+    && tar -vxjf htslib-1.9.tar.bz2 \
+    && cd htslib-1.9 \
+    && make \
+    && make install
+RUN cpanm Bio::DB::HTS
+# above can be deleted once dependency on Bio::DB::HTS goes away
+
+# install Novograph
+RUN cd /opt \
+    && git clone https://github.com/NCBI-Hackathons/NovoGraph.git \
+    && cd NovoGraph/src \
+    && make all
+
+ENV PATH="/opt/NovoGraph/src:${PATH}"
+
+WORKDIR /opt/NovoGraph/scripts

--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ for file in `echo LKPB01.1.fsa_nt.gz LKPB01.2.fsa_nt.gz LKPB01.3.fsa_nt.gz LKPB0
 ```
 Upon the successful download of these FASTAs, users should concatenate the individual assemblies into a single FASTA, `allContigs.fa`.
 
+### Docker 
+
+The most update Docker image can be found here: https://hub.docker.com/r/diltheygenomicslab/novograph
+
+Please see the Dockerfile within the repository.
+
 ### Data Availability
 
 The genome graph of seven ethnically diverse human genomes can be accessed at the following Open Science Framework (OSF) project, [NovoGraph](https://osf.io/3vs42/?view_only=fedd8437d96c4d688f6c40150903d857)


### PR DESCRIPTION
* Revised README to point users to Dockerhub. 
* Added the Dockerfile developed by @TorHou , which uses Bio::DB::HTS

If we no longer use this perl module, we could comment those steps out in the Dockerfile, and re-version the image