### PR TITLE
BUGFIX: This resolves a corner case.

### DIFF
--- a/scripts/BAM2MAFFT.pl
+++ b/scripts/BAM2MAFFT.pl
@@ -201,7 +201,7 @@ my $process_collected_read_data = sub {
 		my $middleWindowPos = $potentialWindowPos + $targetWindowSize;
 		my $minWindowsPos = $middleWindowPos - $scanTarget;
 		my $maxWindowsPos = $middleWindowPos + $scanTarget;
-		last if($minWindowsPos >= $#contig_coverage);
+		last if($middleWindowsPos >= $#contig_coverage);
 		
 		$minWindowsPos = 0 if($minWindowsPos < 0);
 		$maxWindowsPos = $#contig_coverage if ($maxWindowsPos > $#contig_coverage);


### PR DESCRIPTION
The problem occurred when minWindowPos was within chromosome limits, but the coverage was 0. That lead to middleWindowPos being added to the window_positions array which could be bigger than the chromosomes length.