### PR TITLE
qsub default off

### DIFF
--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -13,8 +13,10 @@ use FindBin;
 use File::Spec;
 use List::Util qw/shuffle/;
 use Cwd;
+use FindBin;                 # locate this script
+use lib $FindBin::Bin;       # finds all modules in script directory
+use lib "$FindBin::Bin/..";  # use the parent directory
 use MSAandBAM;  ## module MSAandBAM.pm
-use lib $FindBin::Bin; # finds all modules in script directory
 my $current_dir = getcwd;
 
 $| = 1;

--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -47,11 +47,10 @@ my $mafftDirectory;
 my $action;
 my $inputTruncatedReads;
 my $readsFasta;
-my $paranoid = 1;
 my $chunkSize = 5;
 my $processChunk;
 my $chunkI;
-my $qsub = 1;
+my $qsub = 0;  ## by default, --qsub isn't called
 my $path_to_script = $FindBin::Bin.'/'.$FindBin::Script;
 my $temp_qsub = 'temp_qsub';
 my $reprocess;

--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -13,6 +13,7 @@ use FindBin;
 use File::Spec;
 use List::Util qw/shuffle/;
 use Cwd;
+use MSAandBAM;  ## module MSAandBAM.pm
 use lib $FindBin::Bin; # finds all modules in script directory
 my $current_dir = getcwd;
 

--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -13,10 +13,9 @@ use FindBin;
 use File::Spec;
 use List::Util qw/shuffle/;
 use Cwd;
-use FindBin;                 # locate this script
-use lib $FindBin::Bin;       # finds all modules in script directory
-use lib "$FindBin::Bin/..";  # use the parent directory
-use MSAandBAM;  ## module MSAandBAM.pm
+use FindBin;              ## locate this script
+use lib "$FindBin::Bin";  
+use MSAandBAM;            ## module MSAandBAM.pm
 my $current_dir = getcwd;
 
 $| = 1;


### PR DESCRIPTION
Related to this discussion:

https://github.com/NCBI-Hackathons/NovoGraph/issues/39

* By default, the `qsub` flag should have the value false, and it become true if the flag used.
* Removed `$paranoid` debugging variable. 
