### PR TITLE
Fix to job array edge case

### DIFF
--- a/scripts/CALLMAFFT.pl
+++ b/scripts/CALLMAFFT.pl
@@ -384,6 +384,11 @@ sub invoke_self_array
 		open(QSUB, '>', $temp_qsub) or die "Cannot open $temp_qsub";
 		my $minJobID = 1;
 		my $maxJobID = $maxChunk_0based + 1;
+		## task ids of a job array, should at least be 1
+		## ${minJobID}-${maxJobID}
+		if ($minJobID==1 && $maxJobID==1){
+			$maxJobID = 2;
+		}
 		if($PBSPro)
 		{
 		print QSUB qq(#!/bin/bash


### PR DESCRIPTION
Hi @TorHou 

I think this is a moderately easy way to fix https://github.com/NCBI-Hackathons/NovoGraph/issues/20

I don't use this approach, as no one has the stomach to write this logic: 
> So probably it would be a good idea to check whether the number of files to process is smaller than $chunkSize and submit a job array only if necessary.

Rather, always submit a job array, but make sure the syntax is correct. 

I haven't given this a shot, so please try it out first. 

Best, Evan

